### PR TITLE
fix: allow for no timestamp in FailureReason models

### DIFF
--- a/src/models/attempt_failure_reason.rs
+++ b/src/models/attempt_failure_reason.rs
@@ -24,11 +24,11 @@ pub struct AttemptFailureReason {
     #[serde(rename = "retryable", skip_serializing_if = "Option::is_none")]
     pub retryable: Option<bool>,
     #[serde(rename = "timestamp")]
-    pub timestamp: i64,
+    pub timestamp: Option<i64>,
 }
 
 impl AttemptFailureReason {
-    pub fn new(timestamp: i64) -> AttemptFailureReason {
+    pub fn new(timestamp: Option<i64>) -> AttemptFailureReason {
         AttemptFailureReason {
             failure_origin: None,
             failure_type: None,

--- a/src/models/failure_reason.rs
+++ b/src/models/failure_reason.rs
@@ -24,11 +24,11 @@ pub struct FailureReason {
     #[serde(rename = "retryable", skip_serializing_if = "Option::is_none")]
     pub retryable: Option<bool>,
     #[serde(rename = "timestamp")]
-    pub timestamp: i64,
+    pub timestamp: Option<i64>,
 }
 
 impl FailureReason {
-    pub fn new(timestamp: i64) -> FailureReason {
+    pub fn new(timestamp: Option<i64>) -> FailureReason {
         FailureReason {
             failure_origin: None,
             failure_type: None,


### PR DESCRIPTION
# Changes

<!-- describe contents of the change -->
Allow for no timestamp in FailureReason models. Required by https://github.com/fathom-io/data-ingestion/pull/34.

# Ticket

<!-- link to the ticket -->
https://app.clickup.com/t/8695akzhp

# Checklist

- [ ] Tests written / changed
- [ ] Documentation updated
- [ ] Changelog updated
- [ ] Deployment updated
